### PR TITLE
prevent unhandled rejection

### DIFF
--- a/src/Webform.js
+++ b/src/Webform.js
@@ -1232,7 +1232,7 @@ export default class Webform extends NestedComponent {
     this.submitting = true;
     return this.submitForm(options)
       .then(({ submission, saved }) => this.onSubmit(submission, saved))
-      .catch((err) => Promise.reject(this.onSubmissionError(err)));
+      .catch((err) => this.onSubmissionError(err));
   }
 
   /**


### PR DESCRIPTION
* The library is not catching this rejection in submit logic. We still need to use this event in order to allow form validations and submit button behavior.